### PR TITLE
#1 - Fix rendering resultTemplate

### DIFF
--- a/cloud/aws/compute.yaml
+++ b/cloud/aws/compute.yaml
@@ -70,7 +70,7 @@ node_types:
                   }
             resultTemplate:
               attributes:
-                boot_image: "{{ outputs.boot_image.value }}"
+                boot_image: "{{ outputs.boot_image }}"
 
   unfurl.nodes.Compute:
     derived_from: unfurl.nodes.ComputeAbstract


### PR DESCRIPTION
We get AMI but resultTemplate returns error -> AMI is not save to ensamble.yaml

```
unfurl.task:WARNING: error processing resultTemplate for dockerhost-bootimage: error updating resource dockerhost-bootimage: <<Error rendering template: missing attribute or key: "value">>
```