### PR TITLE
#1 - Fix output attributes of GCP

### DIFF
--- a/cloud/gcp/compute.yaml
+++ b/cloud/gcp/compute.yaml
@@ -124,6 +124,7 @@ node_types:
             }
 
             output "instance" {
+              sensitive = true
               value = google_compute_instance.app
             }
 
@@ -134,11 +135,11 @@ node_types:
             inputs:
               resultTemplate:
                 attributes:
-                  public_address: "{{ outputs.instance.value.network_interface[0].access_config[0].nat_ip }}"
-                  private_address: "{{ outputs.instance.value.network_interface[0].network_ip }}"
+                  public_address: "{{ outputs.instance.network_interface[0].access_config[0].nat_ip }}"
+                  private_address: "{{ outputs.instance.network_interface[0].network_ip }}"
                   # id format: projects/{{project}}/zones/{{zone}}/instances/{{name}}
-                  id:  "{{ outputs.instance.value.id }}"
-                  name: "{{ outputs.instance.value.id | basename }}"
+                  id:  "{{ outputs.instance.id }}"
+                  name: "{{ outputs.instance.id | basename }}"
       Install:
         operations:
           check:


### PR DESCRIPTION
Remove `.value` from resultTemplate

Add `sensitive = true` because of this error. This probably happens only with Terraform 1.0:

```
╷
│ Error: Output refers to sensitive values
│ 
│   on main.unfurl.tmp.tf line 59:
│   59: output "instance" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```